### PR TITLE
Fixes issue for gitlab_rails merging

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -17,7 +17,7 @@ class gitlab::config {
   $gitlab_git_http_server = $::gitlab::gitlab_git_http_server
   $gitlab_ci = $::gitlab::gitlab_ci
   $gitlab_pages = $::gitlab::gitlab_pages
-  $gitlab_rails = $::gitlab::gitlab_rails
+  $gitlab_rails = hiera_hash('gitlab::gitlab_rails',$::gitlab::gitlab_rails)
   $high_availability = $::gitlab::high_availability
   $logging = $::gitlab::logging
   $logrotate = $::gitlab::logrotate


### PR DESCRIPTION
Automatic parameter lookup can't merge values from multiple hierarchy levels (https://docs.puppetlabs.com/hiera/3.0/puppet.html#limitations)

This is to fix vshn/puppet-gitlab#66
